### PR TITLE
Nyango/refine constructors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 node_modules
 
 test/espowered
+
+# OSX meta data
+.DS_store
+# emacs, vim
+*~
+*.swp

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -4,7 +4,7 @@
   // namespace todo
   var todo = todo || {};
 
-  todo.Repository = function(enjoR) {
+  todo.repository = function(enjoR) {
     var that = {};
 
     that.gettodos = function(done) {
@@ -23,7 +23,7 @@
     return that;
   };
 
-  todo.Model = function(repository, enjoM) {
+  todo.model = function(repository, enjoM) {
     var that = {};
 
     var fire = enjoM.bindParams(that, {
@@ -87,7 +87,7 @@
     return that;
   };
 
-  todo.FormViewModel = function($view, model, enjoVm) {
+  todo.formViewModel = function($view, model, enjoVm) {
     // view dependencies
     var $url     = $view.find("#todo-url");
     var $content = $view.find("#todo-content");
@@ -134,7 +134,7 @@
     construct();
   };
 
-  todo.ListViewModel = function($view, model, enjoVm) {
+  todo.listViewModel = function($view, model, enjoVm) {
     function construct() {
       render([]);
       enjoVm.init(model, onUpdate);
@@ -200,10 +200,10 @@
     var $formView = $containerView.children("#todo-form");
 
     var e = enjo($);
-    var todoRepository = todo.Repository(e.Repository());
-    var todoModel = todo.Model(todoRepository, e.Model());
-    todo.ListViewModel($listView, todoModel, e.ViewModel());
-    todo.FormViewModel($formView, todoModel, e.ViewModel());
+    var todoRepository = todo.repository(e.repository());
+    var todoModel = todo.model(todoRepository, e.model());
+    todo.listViewModel($listView, todoModel, e.viewModel());
+    todo.formViewModel($formView, todoModel, e.viewModel());
 
     todoModel.init();
   });

--- a/lib/enjo.js
+++ b/lib/enjo.js
@@ -3,7 +3,7 @@ enjo = function($){
   "use strict";
   var enjo = {};
 
-  enjo.Repository = function() {
+  enjo.repository = function() {
     var that = {};
 
     that.get = function(path, done, fail) {
@@ -35,7 +35,7 @@ enjo = function($){
       }).then(done, fail);
     };
 
-    that.delete = function(path, data, done, fail) {
+    that.deleteRepository = function(path, data, done, fail) {
       var defaultFail = function(xhr, status, err) {
         console.error("delete request failed." +
                       " data: " + JSON.stringify(data) + " err: " + err);
@@ -51,7 +51,7 @@ enjo = function($){
     return that;
   };
 
-  enjo.Model = function() {
+  enjo.model = function() {
     var that = {};
 
     that.bindParams = function(model, params) {
@@ -76,7 +76,7 @@ enjo = function($){
     return that;
   };
 
-  enjo.ViewModel = function() {
+  enjo.viewModel = function() {
     var that = {};
 
     that.init = function(model, onUpdate) {
@@ -93,7 +93,6 @@ enjo = function($){
           params[paramName].$view.val(newValue);
         }
       };
-
       initializeBindParams(params, binder);
       return binder;
     };


### PR DESCRIPTION
多くが大文字始まりのメソッドになってるのは[コーディングスタイル](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml)的に`new`を必要とする関数に思われる。
しかしサンプルを見る限りだと想定されていない。

より綺麗に書けると思ったため、クロージャを用いて一部書きなおしてみた。
